### PR TITLE
Add variable %host% to provide lowercase hostname

### DIFF
--- a/Carbonator/App.config
+++ b/Carbonator/App.config
@@ -33,6 +33,7 @@
       special variables:
       
       %HOST%  -  substitutes current computer name (Environment.MachineName)
+      %host%  -  substitutes current computer name forced in lowercase
       
       -->
     <counters>

--- a/Carbonator/CarbonatorInstance.cs
+++ b/Carbonator/CarbonatorInstance.cs
@@ -183,8 +183,10 @@ namespace Crypton.Carbonator
         /// <returns></returns>
         public static string getMetricPath(string configuredPath)
         {
+            // one and only special variable so far
             return configuredPath
-                .Replace("%HOST%", Environment.MachineName); // one and only special variable so far
+                .Replace("%HOST%", Environment.MachineName)
+                .Replace("%host%", Environment.MachineName.ToLowerInvariant());
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to determine which counters you may be interested (and which are available).
 The configuration for each performance counter element is self explanatory:
 
 - `path` = the Graphite/Carbon metric path that will be reported. 
-  You can use ``%HOST%`` special string in the `path` setting which will be replaced with the name of the current computer when metric is reported.
+  You can use ``%HOST%`` special string in the `path` setting which will be replaced with the name of the current computer when metric is reported. Use ``%host%`` to force the hostname in lowercase.
 - `category` = Performance Counter category
 - `counter` = Performance Counter name
 - `instance` = Performance Counter instance, needed by certain counters such as Processor (_Total to represent overall CPU usage or by specific CPU instead).


### PR DESCRIPTION
Simple change adding the possibility to use %host% instead of %HOST% to substitute the lowercase hostname (more compliant with graphite conventions).
Backward compatible since %HOST% behaviour does not change.
