### PR TITLE
Predefined prefix for metrics

### DIFF
--- a/Carbonator/CarbonatorInstance.cs
+++ b/Carbonator/CarbonatorInstance.cs
@@ -199,7 +199,7 @@ namespace Crypton.Carbonator
                     string metricStr = metric.ToString();
                     // see http://graphite.readthedocs.org/en/latest/feeding-carbon.html
                     Log.Debug("[reportMetrics] reporting: {0}", metricStr.Substring(0, metricStr.Length - 1)); // the Length-1 is to remove the newline at the end for nicer log
-                    byte[] bytes = Encoding.ASCII.GetBytes(conf.Graphite.Prefix + metricStr);
+                    byte[] bytes = Encoding.ASCII.GetBytes(metricStr);
                     try
                     {
                         ns.Write(bytes, 0, bytes.Length);

--- a/Carbonator/CarbonatorInstance.cs
+++ b/Carbonator/CarbonatorInstance.cs
@@ -199,7 +199,7 @@ namespace Crypton.Carbonator
                     string metricStr = metric.ToString();
                     // see http://graphite.readthedocs.org/en/latest/feeding-carbon.html
                     Log.Debug("[reportMetrics] reporting: {0}", metricStr.Substring(0, metricStr.Length - 1)); // the Length-1 is to remove the newline at the end for nicer log
-                    byte[] bytes = Encoding.ASCII.GetBytes(metricStr);
+                    byte[] bytes = Encoding.ASCII.GetBytes(conf.Graphite.Prefix + metricStr);
                     try
                     {
                         ns.Write(bytes, 0, bytes.Length);

--- a/Carbonator/Config/GraphiteExportElement.cs
+++ b/Carbonator/Config/GraphiteExportElement.cs
@@ -32,5 +32,15 @@ namespace Crypton.Carbonator.Config
             set { base["port"] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets destination Graphite server port (default 2003)
+        /// </summary>
+        [ConfigurationProperty("prefix", IsRequired = false, DefaultValue = "")]
+        public string Prefix
+        {
+            get { return (string)base["prefix"]; }
+            set { base["prefix"] = value; }
+        }
+
     }
 }

--- a/Carbonator/Config/GraphiteExportElement.cs
+++ b/Carbonator/Config/GraphiteExportElement.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text;
+﻿using System.Configuration;
 
 namespace Crypton.Carbonator.Config
 {
@@ -33,7 +29,7 @@ namespace Crypton.Carbonator.Config
         }
 
         /// <summary>
-        /// Gets or sets destination Graphite server port (default 2003)
+        /// Gets or sets prefix that added to each metric sent to Graphite server
         /// </summary>
         [ConfigurationProperty("prefix", IsRequired = false, DefaultValue = "")]
         public string Prefix

--- a/Carbonator/MetricPathBuilder.cs
+++ b/Carbonator/MetricPathBuilder.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.DirectoryServices.ActiveDirectory;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Crypton.Carbonator
@@ -84,6 +81,11 @@ namespace Crypton.Carbonator
         }
 
         /// <summary>
+        /// The prefix to add to each metric
+        /// </summary>
+        private string Prefix;
+
+        /// <summary>
         /// Creates a new instance of MetricPathBuilder
         /// </summary>
         public MetricPathBuilder()
@@ -93,6 +95,12 @@ namespace Crypton.Carbonator
             // set defaults
             Domain = cachedDomainName ?? (cachedDomainName = ResolveDomainName()); // resolve & cache the domain name
             Host = Environment.MachineName;
+            var conf = Config.CarbonatorSection.Current;
+
+            if (conf != null)
+            {
+                Prefix = conf.Graphite.Prefix;
+            }
         }
 
         /// <summary>
@@ -139,6 +147,12 @@ namespace Crypton.Carbonator
             {
                 template = template.Replace("%" + key + "%", ReplaceInvalidCharactersInPath(Variables[key]));
             }
+
+            if (!string.IsNullOrEmpty(Prefix))
+            {
+                template = Prefix + template;
+            }
+
             return template;
         }
 


### PR DESCRIPTION
Hey,
I've added an option to prefix all the metrics with const value.
This is necessary for services like HostedGraphite where the api key should be the first sent data.
