### PR TITLE
Make NextValue call on initial PerformanceCounters

### DIFF
--- a/Carbonator.Tests/CounterWatcherTests.cs
+++ b/Carbonator.Tests/CounterWatcherTests.cs
@@ -55,5 +55,23 @@ namespace Carbonator.Tests
 
 
         }
+
+        [TestMethod]
+        public void TestFirstPctIdleTimeValue()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            CounterWatcher watcher = new CounterWatcher();
+            watcher.MetricPath = "PerfMon.MES.%HOST%.Processor.PctIdleTime.%COUNTER_INSTANCE%";
+            watcher.CategoryName = "Processor";
+            watcher.CounterName = "% Idle Time";
+            watcher.InstanceNames = @"_Total";
+            watcher.Initialize();
+
+            List<CollectedMetric> metrics = new List<CollectedMetric>();
+            watcher.Report(metrics);
+            Assert.IsTrue(metrics[0].Value > 0f, "First sample for % Idle Time should be greater than zero");
+        }
     }
 }

--- a/Carbonator/CounterWatcher.cs
+++ b/Carbonator/CounterWatcher.cs
@@ -110,7 +110,7 @@ namespace Crypton.Carbonator
 
                     // filter by counter names
                     var filtered = counters.Where(c => Regex.IsMatch(c.CounterName, CounterName));
-                    _counters.AddRange(filtered);
+                    AddCounters(filtered);
                 }
             }
             else
@@ -118,7 +118,7 @@ namespace Crypton.Carbonator
                 // match counters
                 var counters = counterCategory.GetCounters();
                 var filtered = counters.Where(c => Regex.IsMatch(c.CounterName, CounterName));
-                _counters.AddRange(filtered);
+                AddCounters(filtered);
             }
         }
 
@@ -160,6 +160,17 @@ namespace Crypton.Carbonator
                 counter.Dispose();
             }
             _counters.Clear();
+        }
+
+        private void AddCounters(IEnumerable<PerformanceCounter> filtered)
+        {
+            foreach (var counter in filtered)
+            {
+                // Some performance counters require deltas to give sensible values. By calling NextValue
+                // on each of our counters, we prime them to return correct one each subsequent call.
+                counter.NextValue();
+                _counters.Add(counter);
+            }        
         }
     }
 }


### PR DESCRIPTION
Some performance counters are deltas, and will return 0 on the first
call to NextValue. By priming the counters with an initial call, we
can avoid erroneous reported data.